### PR TITLE
added 'http://' to aut links for sending forms

### DIFF
--- a/slides/lecture-3/index.html
+++ b/slides/lecture-3/index.html
@@ -1208,7 +1208,7 @@ Please enter your message</textarea
     </ul>
   </section>
   <section>
-    <form action="www.aut.ac.ir" method="get">
+    <form action="http://www.aut.ac.ir" method="get">
       <fieldset>
         <legend>University Grade</legend>
         <input type="radio" name="grade" value="B" /> BS <br />
@@ -1221,7 +1221,7 @@ Please enter your message</textarea
   </section>
   <section>
     <pre><code class="lang-html">
-&lt;form action="www.aut.ac.ir" method="get"&gt;
+&lt;form action="http://www.aut.ac.ir" method="get"&gt;
   &lt;fieldset&gt;
     &lt;legend&gt;University Grade&lt;/legend&gt;
     &lt;input type="radio" name="grade" value="B" /&gt; BS &lt;br /&gt;


### PR DESCRIPTION
in sending form in HTML lecture [here](https://sbu-ce.github.io/IE-lecture/slides/lecture-3/index.html#/32/9), action link is relative and will continue to 404 page in GitHub.
 
I fixed it by adding `http://` to link and make it absolute.
